### PR TITLE
Resolve open CodeQL security alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default: this workflow only checks out the repo and runs
+# tests, so the GITHUB_TOKEN needs read access to repository contents and
+# nothing more.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

ugit currently has 3 open CodeQL alerts. This PR resolves the one real issue in code and documents why the other two are safe to dismiss, so the Security tab can return to green.

## 1. Workflow missing permissions (alert #5, warning) — FIXED HERE

`.github/workflows/test.yml` had no `permissions` block, so `GITHUB_TOKEN` defaulted to broad read/write. The workflow only checks out the repo and runs pytest, so this PR pins it to least privilege:

```yaml
permissions:
  contents: read
```

## 2. Clear-text logging of password (alert #4, error) — recommend dismiss as "false positive"

`ugit.py:252` prints a summary after `create_config()`:

```python
field_names = [k for k in cfg if cfg[k]]      # collects KEY NAMES, e.g. 'password'
print('Fields stored: %s' % ', '.join(field_names))
```

The printed list contains config **key names** (`ssid, password, user, ...`), never the credential **values**. CodeQL's taint tracker flags it only because the list is derived from the credential-bearing dict. No secret is ever logged.

Recommended action: dismiss alert #4 as **false positive**.

## 3. Clear-text storage of password (alert #3, error) — recommend dismiss as "won't fix"

`ugit.py:247` writes the config (WiFi password + optional GitHub token) to `config.json`:

```python
f = open(_CONFIG_PATH, 'w')
f.write(json.dumps(cfg))
```

MicroPython on ESP32 has no secure keychain or hardware secure-element accessible to user code. On-device plaintext storage is the only option for credentials the device needs at boot to join WiFi and pull updates. The code already:

- documents the constraint in an inline comment,
- auto-protects `config.json` from being synced/committed,
- masks secrets in `show_config()`.

Recommended action: dismiss alert #3 as **won't fix** with a note about the platform constraint.

## After merge

Dismiss alerts #3 and #4 from the [Security tab](https://github.com/turfptax/ugit/security/code-scanning) with the reasons above. Alert #5 closes automatically once this workflow change lands.